### PR TITLE
Enable/disable GZip support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,17 @@
 Overview
 =======
-Granule is an optimization solution for Java-based web applications (JSP, JSF, Grails). It combines and compresses JavaScript and CSS files into less granulated packages, increasing speed and saving bandwidth.
+This repository forked from [JonathanWalsh/Granule](JonathanWalsh/Granule)
 
-The granule solution includes: 
+I was using Granule in one of my project.
 
-  *   JSP Tag library. You just need put the tag around your StyleSheets and JavaScripts to compress and combine them.
-  *   Ant task, to include pre-compressing in your build scripts. 
+The issue I faced was, by default I was gZipping all the files served from my server.
 
+Granule, by default giving the gZipped output.
 
-![Example](https://sites.google.com/site/granuletag/_/rsrc/1297244554577/home/demojsphtml.png)
+There might be other ways to disable this, but thought that it would be better to have an option in this library itself.
 
-Granule can automatically choose minimization algorithms by content from simple whitespace removal algorithms to advanced methods as Google Closure Compiler. It helps integrate Google Closure Library by automatically calculating dependencies between JS files and providing caching or pre-compiling capabilities. 
+So, Forked and updated the code to have a new option with the name "enable-gzip", which accepts either true or false, by default it is true.
 
-The library organizes work with large sets of web files. It has two modes: development and production, configuration of those can be tuned separately up to turning off any effect of the library at all. 
-
-The library is released under business friendly Apache 2.0 Open Source License. 
-For JDK1.5 use Granule Closure Compiler.
-
-
-List of features
-===========
-  *  Combine and compresses JS and CSS using different methods: on fly or in build process, CSS and JS fast compression or more sophisticated Google Closure compression, or just simple file combining. 
-  *  No-lock in solution. The tag just put around existing scripts. The tag can be turn on/off on the different levels: page and application.
-  *  Debug and production modes.
-  *  Calculate dependencies using Closure Library package/namespace system.
-  *  Can automatically choose optimization methods.
-  *  Multiple combinations of JS/CSS even with different compression methods on one page.
-  *  Support JSP includes.
-  *  Several types of cache, memory and file.
-  *  Automatically regenerates the bundle if you modify an included file.
-  *  Proxy-friendly GZip support.
-  *  Rewrites relative URLs in your CSS files.
-  *  JSP, JSF, Grails integration.
-  *  Multiple loggers support (SLF4J, Log4J, Apache Logger)
-  *  Can be setup to preserve license headers of JS libraries.
-  *  JDK1.5 and higher even for Google Closure Compiler.
-
-## Installation Granule Tag Library ##
-1. Download the binary distribution of Granule Tag Library by following this URL: [http://code.google.com/p/granule/downloads/list](http://code.google.com/p/granule/downloads/list) (granuleNNN.zip) and unpack the compressed file.
-
-2. Copy granuleNNN.jar in the distribution’s ‘lib’ directory to your web applications WEB-NF\lib directory.
-
-3. To use the granule compress tag, you must include taglib directive <%@ taglib uri="http://granule.com/tags" prefix="g" %> at the top of each JSP that uses this library.
-
-4. Copy the <servlet> and <servlet-mapping> declarations from web.xml (look below) from compressed file into your /WEB-INF/web.xml 
-
-		<servlet>
-			<servlet-name>CompressServlet</servlet-name>
-			<servlet-class>com.granule.CompressServlet</servlet-class>
-			<load-on-startup>1</load-on-startup>
-		</servlet>
-		<servlet-mapping>
-			<servlet-name>CompressServlet</servlet-name>
-			<url-pattern>/combined.js</url-pattern>
-		</servlet-mapping>
-		<servlet-mapping>
-			<servlet-name>CompressServlet</servlet-name>
-			<url-pattern>/combined.css</url-pattern>
-		</servlet-mapping>
-
-5. Put <g:compress> tags around the lists of script decorations (JS or CSS). For example -
-	
-		<g:compress>
-		  <link rel="stylesheet" type="text/css" href="css/dp.css"/>
-		  <link rel="stylesheet" type="text/css" href="css/demo.css"/>	
-		</g:compress>
-		...
-		<div id="datepicker"></div>
-		  <g:compress>
-			<script type="text/javascript" src="common.js"/>
-			<script type="text/javascript" src="closure/goog/base.js"/>
-			<script>
-			  goog.require('goog.dom');
-			  goog.require('goog.date');
-			  goog.require('goog.ui.DatePicker');
-		   </script>
-		  <script type="text/javascript">
-			var dp = new goog.ui.DatePicker();
-			dp.render(document.getElementById('datepicker'));
-		  </script>
-		 </g:compress>
-		...
-	
-
-6.  Done. Run your web application and check output html source. It should convert CSS and JS declarations similar to this.
-
-    <link rel="stylesheet" type="text/css" 
-      href="/combined.css?id=cc4c21b0"/>    
-    
-    <script src="/combined.js?id=4658acf30"/>
+More Information
+=======
+More information about Granule can be found at [JonathanWalsh/Granule](JonathanWalsh/Granule)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,91 @@
 Overview
 =======
-This repository forked from [JonathanWalsh/Granule](JonathanWalsh/Granule)
+Granule is an optimization solution for Java-based web applications (JSP, JSF, Grails). It combines and compresses JavaScript and CSS files into less granulated packages, increasing speed and saving bandwidth.
 
-I was using Granule in one of my project.
+The granule solution includes: 
 
-The issue I faced was, by default I was gZipping all the files served from my server.
+  *   JSP Tag library. You just need put the tag around your StyleSheets and JavaScripts to compress and combine them.
+  *   Ant task, to include pre-compressing in your build scripts. 
 
-Granule, by default giving the gZipped output.
 
-There might be other ways to disable this, but thought that it would be better to have an option in this library itself.
+![Example](https://sites.google.com/site/granuletag/_/rsrc/1297244554577/home/demojsphtml.png)
 
-So, Forked and updated the code to have a new option with the name "enable-gzip", which accepts either true or false, by default it is true.
+Granule can automatically choose minimization algorithms by content from simple whitespace removal algorithms to advanced methods as Google Closure Compiler. It helps integrate Google Closure Library by automatically calculating dependencies between JS files and providing caching or pre-compiling capabilities. 
 
-More Information
-=======
-More information about Granule can be found at [JonathanWalsh/Granule](JonathanWalsh/Granule)
+The library organizes work with large sets of web files. It has two modes: development and production, configuration of those can be tuned separately up to turning off any effect of the library at all. 
+
+The library is released under business friendly Apache 2.0 Open Source License. 
+For JDK1.5 use Granule Closure Compiler.
+
+
+List of features
+===========
+  *  Combine and compresses JS and CSS using different methods: on fly or in build process, CSS and JS fast compression or more sophisticated Google Closure compression, or just simple file combining. 
+  *  No-lock in solution. The tag just put around existing scripts. The tag can be turn on/off on the different levels: page and application.
+  *  Debug and production modes.
+  *  Calculate dependencies using Closure Library package/namespace system.
+  *  Can automatically choose optimization methods.
+  *  Multiple combinations of JS/CSS even with different compression methods on one page.
+  *  Support JSP includes.
+  *  Several types of cache, memory and file.
+  *  Automatically regenerates the bundle if you modify an included file.
+  *  Proxy-friendly GZip support.
+  *  Rewrites relative URLs in your CSS files.
+  *  JSP, JSF, Grails integration.
+  *  Multiple loggers support (SLF4J, Log4J, Apache Logger)
+  *  Can be setup to preserve license headers of JS libraries.
+  *  JDK1.5 and higher even for Google Closure Compiler.
+
+## Installation Granule Tag Library ##
+1. Download the binary distribution of Granule Tag Library by following this URL: [http://code.google.com/p/granule/downloads/list](http://code.google.com/p/granule/downloads/list) (granuleNNN.zip) and unpack the compressed file.
+
+2. Copy granuleNNN.jar in the distribution’s ‘lib’ directory to your web applications WEB-NF\lib directory.
+
+3. To use the granule compress tag, you must include taglib directive <%@ taglib uri="http://granule.com/tags" prefix="g" %> at the top of each JSP that uses this library.
+
+4. Copy the <servlet> and <servlet-mapping> declarations from web.xml (look below) from compressed file into your /WEB-INF/web.xml 
+
+		<servlet>
+			<servlet-name>CompressServlet</servlet-name>
+			<servlet-class>com.granule.CompressServlet</servlet-class>
+			<load-on-startup>1</load-on-startup>
+		</servlet>
+		<servlet-mapping>
+			<servlet-name>CompressServlet</servlet-name>
+			<url-pattern>/combined.js</url-pattern>
+		</servlet-mapping>
+		<servlet-mapping>
+			<servlet-name>CompressServlet</servlet-name>
+			<url-pattern>/combined.css</url-pattern>
+		</servlet-mapping>
+
+5. Put <g:compress> tags around the lists of script decorations (JS or CSS). For example -
+	
+		<g:compress>
+		  <link rel="stylesheet" type="text/css" href="css/dp.css"/>
+		  <link rel="stylesheet" type="text/css" href="css/demo.css"/>	
+		</g:compress>
+		...
+		<div id="datepicker"></div>
+		  <g:compress>
+			<script type="text/javascript" src="common.js"/>
+			<script type="text/javascript" src="closure/goog/base.js"/>
+			<script>
+			  goog.require('goog.dom');
+			  goog.require('goog.date');
+			  goog.require('goog.ui.DatePicker');
+		   </script>
+		  <script type="text/javascript">
+			var dp = new goog.ui.DatePicker();
+			dp.render(document.getElementById('datepicker'));
+		  </script>
+		 </g:compress>
+		...
+	
+
+6.  Done. Run your web application and check output html source. It should convert CSS and JS declarations similar to this.
+
+    <link rel="stylesheet" type="text/css" 
+      href="/combined.css?id=cc4c21b0"/>    
+    
+    <script src="/combined.js?id=4658acf30"/>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ List of features
   *  Several types of cache, memory and file.
   *  Automatically regenerates the bundle if you modify an included file.
   *  Proxy-friendly GZip support.
+  *  Optional disable GZip support.
   *  Rewrites relative URLs in your CSS files.
   *  JSP, JSF, Grails integration.
   *  Multiple loggers support (SLF4J, Log4J, Apache Logger)

--- a/jsp-demo/web/WEB-INF/granule.properties
+++ b/jsp-demo/web/WEB-INF/granule.properties
@@ -61,3 +61,8 @@ keepfirstcommentpath=js/dojo/*,js/superslider/slider.js,js/jquery*.js
 # contextroot - the constant context root of web-applications. 
 # It need to be setup right for ant cache precompiling if there are hard-coded URLs in the pages
 contextroot=web
+
+#Enable/Disable GZip support
+#   Values : true, false
+#   Default : true
+enable-gzip=true

--- a/tag-main/src/com/granule/CompressorHandler.java
+++ b/tag-main/src/com/granule/CompressorHandler.java
@@ -53,7 +53,7 @@ public class CompressorHandler {
             
             OutputStream os = response.getOutputStream();
             try {
-                if (gzipSupported(request)) {
+                if (settings.getEnableGZip() && gzipSupported(request)) {
                     response.setHeader("Content-Encoding", "gzip");
                     os.write(bundle.getBundleValue());
                 } else

--- a/tag-main/src/com/granule/CompressorSettings.java
+++ b/tag-main/src/com/granule/CompressorSettings.java
@@ -50,6 +50,7 @@ public class CompressorSettings {
     private String tagName = DEFAULT_TAG_NAME;
     private String contextRoot = null;
 	private String basePath = null;
+	private boolean enableGZip = true;
 
     public static final String NONE_VALUE = "none";
     public static final String CLOSURE_COMPILER_VALUE = "closure-compiler";
@@ -88,6 +89,7 @@ public class CompressorSettings {
     public static final String DEFAULT_TAG_NAME = "g:compress";
     public static final String CONTEXTROOT_KEY = "contextroot";
     public static final String BASEPATH_KEY = "basepath";
+    public static final String ENABLE_GZIP = "enable-gzip";
 
     public String getJsCompressMethod() {
         return jsCompressMethod;
@@ -229,6 +231,9 @@ public class CompressorSettings {
         
         if (props.containsKey(CONTEXTROOT_KEY))
         	contextRoot = props.getProperty(CONTEXTROOT_KEY);
+        
+        if (props.containsKey(ENABLE_GZIP))
+        	enableGZip = getBoolean(props.getProperty(ENABLE_GZIP), enableGZip);
     }
 
     private void readFileListProperty(Utf8Properties props, String settingName, List<String> list) throws IOException {
@@ -312,6 +317,10 @@ public class CompressorSettings {
 
 	public String getBasePath() {
 		return basePath;
+	}
+	
+	public boolean getEnableGZip() {
+		return enableGZip;
 	}
 
     


### PR DESCRIPTION
While working in a project, we came across a situation where our server is gzipping all the content and also Granule gzipping its output.

So, we felt that it would be better to have an option to enable/disable gzip option.

Updated the code to have the same.
