### PR TITLE
Updated regex to ignore absolute path in URL

### DIFF
--- a/tag-main/src/com/granule/utils/CSSHandler.java
+++ b/tag-main/src/com/granule/utils/CSSHandler.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
 public final class CSSHandler {
     private static final String stringLiteralRegex = "(\"(?:\\.|[^\\\"])*\"|'(?:\\.|[^\\'])*')";
     private static final String urlRegex = String.format(
-            "(?:url\\(\\s*(%s|[^)]*)\\s*\\))", stringLiteralRegex);
+            "(?:url\\(\\s*(?!\\s*\\'\\/)(?!\\s*\\\"\\/)(?!\\s*\\/)(%s|[^)]*)\\s*\\))", stringLiteralRegex);
     private static final String importRegex = String.format(
             "(?:@import\\s+(%s|%s))", urlRegex, stringLiteralRegex);
 


### PR DESCRIPTION
Fixed the issue logged at :
http://code.google.com/p/granule/issues/detail?id=16

Proof of concept for Regex can be found at :
http://refiddle.com/ghc
