### PR TITLE
Added a property that turn on/off  gzip compression of css and js files.

### DIFF
--- a/grails-demo/web-app/WEB-INF/granule.properties
+++ b/grails-demo/web-app/WEB-INF/granule.properties
@@ -54,4 +54,8 @@ closure-compiler.add-path=js/closure-samples/
 
 keepfirstcommentpath=js/dojo/*,js/superslider/slider.js,js/jquery*.js
 
+#If set to true, JS and CSS files are returned after gzip compression
+#By default, this is set to true. 
+#If server is already configured to gzip response for some reasons, then set this flag to false to avoid double gzip compression.
+gzip.output=true
 

--- a/jsp-demo/web/WEB-INF/granule.properties
+++ b/jsp-demo/web/WEB-INF/granule.properties
@@ -61,3 +61,8 @@ keepfirstcommentpath=js/dojo/*,js/superslider/slider.js,js/jquery*.js
 # contextroot - the constant context root of web-applications. 
 # It need to be setup right for ant cache precompiling if there are hard-coded URLs in the pages
 contextroot=web
+
+#If set to true, JS and CSS files are returned after gzip compression
+#By default, this is set to true. 
+#If server is already configured to gzip response for some reasons, then set this flag to false to avoid double gzip compression.
+gzip.output=true

--- a/tag-main/src/com/granule/CachedBundle.java
+++ b/tag-main/src/com/granule/CachedBundle.java
@@ -115,11 +115,7 @@ public class CachedBundle {
             if (dep instanceof ExternalFragment && !hash.contains("/" + ((ExternalFragment) dep).getFilePath()))
                 dependentFragments.add(dep);
         try {
-            if(settings.isGzipOutput()){
-                bundleValue = gzip(text);
-            } else {
-                bundleValue = text.getBytes();
-            }
+            bundleValue = gzip(text);
         } catch (IOException e) {
             throw new JSCompileException(e);
         }
@@ -144,11 +140,7 @@ public class CachedBundle {
             text = Compressor.unifyCss(fragments, dependentFragments, settings, request);
 
         try {
-            if(settings.isGzipOutput()){
-                bundleValue = gzip(text);
-            } else {
-                bundleValue = text.getBytes();
-            }
+            bundleValue = gzip(text);
         } catch (IOException e) {
             throw new JSCompileException(e);
         }

--- a/tag-main/src/com/granule/CachedBundle.java
+++ b/tag-main/src/com/granule/CachedBundle.java
@@ -115,7 +115,11 @@ public class CachedBundle {
             if (dep instanceof ExternalFragment && !hash.contains("/" + ((ExternalFragment) dep).getFilePath()))
                 dependentFragments.add(dep);
         try {
-            bundleValue = gzip(text);
+            if(settings.isGzipOutput()){
+                bundleValue = gzip(text);
+            } else {
+                bundleValue = text.getBytes();
+            }
         } catch (IOException e) {
             throw new JSCompileException(e);
         }
@@ -140,7 +144,11 @@ public class CachedBundle {
             text = Compressor.unifyCss(fragments, dependentFragments, settings, request);
 
         try {
-            bundleValue = gzip(text);
+            if(settings.isGzipOutput()){
+                bundleValue = gzip(text);
+            } else {
+                bundleValue = text.getBytes();
+            }
         } catch (IOException e) {
             throw new JSCompileException(e);
         }

--- a/tag-main/src/com/granule/CompressorHandler.java
+++ b/tag-main/src/com/granule/CompressorHandler.java
@@ -53,7 +53,7 @@ public class CompressorHandler {
             
             OutputStream os = response.getOutputStream();
             try {
-                if (gzipSupported(request)) {
+                if (settings.isGzipOutput() && gzipSupported(request)) {
                     response.setHeader("Content-Encoding", "gzip");
                     os.write(bundle.getBundleValue());
                 } else

--- a/tag-main/src/com/granule/CompressorSettings.java
+++ b/tag-main/src/com/granule/CompressorSettings.java
@@ -246,7 +246,7 @@ public class CompressorSettings {
         if (props.containsKey(CONTEXTROOT_KEY))
         	contextRoot = props.getProperty(CONTEXTROOT_KEY);
         
-        if(props.contains(GZIP_OUTPUT_KEY)){
+        if(props.containsKey(GZIP_OUTPUT_KEY)){
             gzipOutput = getBoolean(props.getProperty(GZIP_OUTPUT_KEY), gzipOutput);
         }
     }

--- a/tag-main/src/com/granule/CompressorSettings.java
+++ b/tag-main/src/com/granule/CompressorSettings.java
@@ -50,6 +50,7 @@ public class CompressorSettings {
     private String tagName = DEFAULT_TAG_NAME;
     private String contextRoot = null;
 	private String basePath = null;
+	private boolean gzipOutput = true;
 
     public static final String NONE_VALUE = "none";
     public static final String CLOSURE_COMPILER_VALUE = "closure-compiler";
@@ -88,6 +89,7 @@ public class CompressorSettings {
     public static final String DEFAULT_TAG_NAME = "g:compress";
     public static final String CONTEXTROOT_KEY = "contextroot";
     public static final String BASEPATH_KEY = "basepath";
+    public static final String GZIP_OUTPUT_KEY = "gzip.output";
 
     public String getJsCompressMethod() {
         return jsCompressMethod;
@@ -131,6 +133,20 @@ public class CompressorSettings {
 
     public String getTagName() {
         return tagName;
+    }   
+
+    /**
+     * @return Returns the gzipOutput.
+     */
+    public boolean isGzipOutput() {
+        return gzipOutput;
+    }
+
+    /**
+     * @param gzipOutput The gzipOutput to set.
+     */
+    public void setGzipOutput(boolean gzipOutput) {
+        this.gzipOutput = gzipOutput;
     }
 
     public void load(Utf8Properties props) throws IOException {
@@ -229,6 +245,10 @@ public class CompressorSettings {
         
         if (props.containsKey(CONTEXTROOT_KEY))
         	contextRoot = props.getProperty(CONTEXTROOT_KEY);
+        
+        if(props.contains(GZIP_OUTPUT_KEY)){
+            gzipOutput = getBoolean(props.getProperty(GZIP_OUTPUT_KEY), gzipOutput);
+        }
     }
 
     private void readFileListProperty(Utf8Properties props, String settingName, List<String> list) throws IOException {

--- a/tag-main/src/com/granule/utils/CSSHandler.java
+++ b/tag-main/src/com/granule/utils/CSSHandler.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
 public final class CSSHandler {
     private static final String stringLiteralRegex = "(\"(?:\\.|[^\\\"])*\"|'(?:\\.|[^\\'])*')";
     private static final String urlRegex = String.format(
-            "(?:url\\(\\s*(%s|[^)]*)\\s*\\))", stringLiteralRegex);
+            "(?:url\\(\\s*(?!\\s*\\'\\/)(?!\\s*\\\"\\/)(?!\\s*\\/)(%s|[^)]*)\\s*\\))", stringLiteralRegex);
     private static final String importRegex = String.format(
             "(?:@import\\s+(%s|%s))", urlRegex, stringLiteralRegex);
 


### PR DESCRIPTION
If suppose, gzip compression is turned on server for all the css files
and granule combined css file can not be omitted from this compression.
gzip compression happens two times, and the combined css / js files may
not work as expected.  So, there must be an option in granule to turn
off gzip compression. a property called gzip.output is added to
configuration. By default this value is set to true. If granule gzip
compression is not required, then this parameter has to be set to false.
