### PR TITLE
Add type="text/javascript" to the generated <script> elem

### DIFF
--- a/tag-main/src/com/granule/CompressTagHandler.java
+++ b/tag-main/src/com/granule/CompressTagHandler.java
@@ -154,7 +154,7 @@ public class CompressTagHandler {
 	                        } else {
 	                            if (fragmentDescriptors.size() > 0) {
 	                                String newText = "<script src=\"" + PathUtils.getContextURL(runtimRequest.getContextPath(),"/combined.js?id="
-	                                        + bundleId) + "\"></script>";
+	                                        + bundleId) + "\" type=\"text/javascript\"></script>";
 	                                newBody = newBody.substring(0, e.getBegin() + correction) + newText
 	                                        + newBody.substring(e.getEnd() + correction);
 	                                correction -= e.getEnd() - e.getBegin();


### PR DESCRIPTION
To be valid HTML, I added the type attribute to the script element.
